### PR TITLE
Add validation for required sheet columns before syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 - `Assignments` : ต้องมีคอลัมน์ `Driver ID`, `Pickup Point ID`
 - `Pickup` : ต้องมีคอลัมน์ `Group Name`, `Pickup Point ID`, `Pickup Point Name`, `Text Address`
 
+> ℹ️ สคริปต์จะตรวจสอบคอลัมน์ที่จำเป็นให้ครบก่อนซิงก์ หากขาดคอลัมน์ใดจะหยุดการทำงานและแจ้งชื่อคอลัมน์ที่หายไป
+
 ## ใช้กับ GitHub Actions
 1) อัปโหลดไฟล์ทั้งหมดขึ้น GitHub repo
 2) เพิ่ม Secrets ที่ Settings → Secrets → Actions


### PR DESCRIPTION
## Summary
- add a custom error to stop the sync when required sheet columns are missing
- pass the required column lists for each tab and document the behavior in the README

## Testing
- node migrate_from_sheets_to_firestore.mjs *(fails: missing local dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5124937588333b6eba6f427fc2e1d