### PR TITLE
Refactor sync helpers and add unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.1.0",
   "type": "module",
   "scripts": {
-    "sync": "node migrate_from_sheets_to_firestore.mjs"
+    "sync": "node migrate_from_sheets_to_firestore.mjs",
+    "test": "node --test"
   },
   "dependencies": {
     "firebase-admin": "^12.7.0",

--- a/src/env.js
+++ b/src/env.js
@@ -1,0 +1,24 @@
+export class MissingEnvVarError extends Error {
+  constructor(name, example) {
+    const extra = example ? ` (เช่น: ${example})` : "";
+    super(`Missing required environment variable '${name}'${extra}.`);
+    this.name = "MissingEnvVarError";
+    this.envName = name;
+    this.example = example;
+  }
+}
+
+export function getEnvOrThrow(name, { parser = value => value, example } = {}) {
+  const raw = process.env[name];
+  if (!raw || !String(raw).trim()) {
+    throw new MissingEnvVarError(name, example);
+  }
+
+  try {
+    return parser(raw);
+  } catch (error) {
+    throw new Error(
+      `Invalid value for environment variable '${name}': ${error.message}`
+    );
+  }
+}

--- a/src/mappers.js
+++ b/src/mappers.js
@@ -1,0 +1,36 @@
+const toStr = value => (value == null ? "" : String(value).trim());
+
+export function mapDriver(row) {
+  const id = toStr(row["Driver ID"]);
+  if (!id) return null;
+  return {
+    __id: id,
+    name: toStr(row["Driver Name"]),
+    idShift: toStr(row["IDShift"]),
+    timeHolidayDate: row["TimeHolidayDate"] ?? null,
+  };
+}
+
+export function mapPickup(row) {
+  const id = toStr(row["Pickup Point ID"]);
+  if (!id) return null;
+  return {
+    __id: id,
+    groupName: toStr(row["Group Name"]),
+    pickupPointName: toStr(row["Pickup Point Name"]),
+    textAddress: toStr(row["Text Address"]),
+  };
+}
+
+export function mapAssignment(row) {
+  const driverId = toStr(row["Driver ID"]);
+  const pickupId = toStr(row["Pickup Point ID"]);
+  if (!driverId || !pickupId) return null;
+  return {
+    __id: `${driverId}__${pickupId}`,
+    driverId,
+    pickupPointId: pickupId,
+  };
+}
+
+export { toStr };

--- a/tests/mappers.test.js
+++ b/tests/mappers.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getEnvOrThrow, MissingEnvVarError } from "../src/env.js";
+import { mapAssignment, mapDriver, mapPickup, toStr } from "../src/mappers.js";
+
+test("toStr converts nullish to empty string", () => {
+  assert.equal(toStr(null), "");
+  assert.equal(toStr(undefined), "");
+  assert.equal(toStr(" abc "), "abc");
+});
+
+test("mapDriver returns null when driver id missing", () => {
+  const row = { "Driver Name": "Alice" };
+  assert.equal(mapDriver(row), null);
+});
+
+test("mapDriver trims values and keeps nullable date", () => {
+  const row = {
+    "Driver ID": " 123 ",
+    "Driver Name": " Alice ",
+    IDShift: " M1 ",
+    TimeHolidayDate: "2024-01-01",
+  };
+  assert.deepEqual(mapDriver(row), {
+    __id: "123",
+    name: "Alice",
+    idShift: "M1",
+    timeHolidayDate: "2024-01-01",
+  });
+});
+
+test("mapPickup handles minimal fields", () => {
+  const row = {
+    "Pickup Point ID": 321,
+    "Group Name": " Group ",
+    "Pickup Point Name": " Point ",
+    "Text Address": " Address ",
+  };
+  assert.deepEqual(mapPickup(row), {
+    __id: "321",
+    groupName: "Group",
+    pickupPointName: "Point",
+    textAddress: "Address",
+  });
+});
+
+test("mapAssignment builds composite id", () => {
+  const row = { "Driver ID": "D1", "Pickup Point ID": "P1" };
+  assert.deepEqual(mapAssignment(row), {
+    __id: "D1__P1",
+    driverId: "D1",
+    pickupPointId: "P1",
+  });
+});
+
+test("mapAssignment returns null when any id missing", () => {
+  assert.equal(mapAssignment({ "Pickup Point ID": "P1" }), null);
+  assert.equal(mapAssignment({ "Driver ID": "D1" }), null);
+});
+
+test("getEnvOrThrow returns parsed value", () => {
+  process.env.TEST_ENV = "42";
+  const result = getEnvOrThrow("TEST_ENV", { parser: Number });
+  assert.equal(result, 42);
+  delete process.env.TEST_ENV;
+});
+
+test("getEnvOrThrow throws MissingEnvVarError", () => {
+  const name = "TEST_MISSING";
+  assert.throws(
+    () => getEnvOrThrow(name),
+    error => error instanceof MissingEnvVarError && error.envName === name
+  );
+});
+
+test("getEnvOrThrow wraps parser errors", () => {
+  process.env.TEST_INVALID = "abc";
+  assert.throws(
+    () => getEnvOrThrow("TEST_INVALID", { parser: value => {
+      const parsed = Number(value);
+      if (Number.isNaN(parsed)) throw new Error("not a number");
+      return parsed;
+    } }),
+    /Invalid value for environment variable 'TEST_INVALID': not a number/
+  );
+  delete process.env.TEST_INVALID;
+});


### PR DESCRIPTION
## Summary
- extract environment parsing and data mapping helpers into dedicated modules
- update the migration script to consume the shared helpers
- add a node:test suite covering env parsing and sheet-to-firestore mappers

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68e5706372d88333b72980c2ec9e7962